### PR TITLE
add nil to NSMutableArray bug fixed

### DIFF
--- a/Pod/Classes/Hashids.m
+++ b/Pod/Classes/Hashids.m
@@ -453,7 +453,10 @@
         {
             NSString *salt = [NSString stringWithFormat:@"%d%@", (lottery_char & 12345), self.hashSalt];
             inAlpha = [self consistentShuffle:inAlpha withSalt:salt];
-            [results addObject:[self unhash:subhash withAlpha:inAlpha]];
+            NSNumber *unhashed = [self unhash:subhash withAlpha:inAlpha];
+            if (unhashed) {
+                [results addObject:unhashed];
+            }
         }
         
     }


### PR DESCRIPTION
Method <code>unhash:withAlpha:</code> can return <code>nil</code>. This could lead to adding <code>nil</code> to an <code>NSMutableArray</code> which will cause a crash.
